### PR TITLE
subprocess.communicate() returning a byte-like-object which needs

### DIFF
--- a/tasks/resolve_reference.py
+++ b/tasks/resolve_reference.py
@@ -49,6 +49,10 @@ args = shlex.split(command)
 
 p = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 output,error = p.communicate()
+try:
+    output = output.decode("utf-8")
+except AttributeError:
+    pass
 if output:
     for target in output.split("\n"):
         if target:


### PR DESCRIPTION
decoding before it can be tested against "\n".